### PR TITLE
Added second test

### DIFF
--- a/session5/4-spec/5.rb
+++ b/session5/4-spec/5.rb
@@ -1,24 +1,34 @@
 errors = Module.constants.grep(/error|exception/i)
 
 RSpec.describe 'list_of_errors_and_exceptions' do
-  %w(
-    Lowercaseerror
-    Lowercaseexception
-    Errorerr
-    Exceptionatstart
-    ExceptionAtStart
-    ExcEPtion
-    Abcexceptiondef
-  ).each do |error_to_find|
-    # changed between 1.8 and 1.9
-    if Module.constants.first.kind_of? Symbol
-      error_to_find = error_to_find.to_sym
-    end
+  it 'finds weird cased errors and exceptions' do
 
-    Object.const_set error_to_find, Class.new(StandardError)
+    %w(Lowercaseerror Lowercaseexception Errorerr Traffickcontrollerror
+      Weirdexceptions Exceptionatstart ExceptionAtStart ExcEPtionf
+      Abcexceptiondef ).each do |error_to_find|
+      # changed between 1.8 and 1.9
+      if Module.constants.first.kind_of? Symbol
+        error_to_find = error_to_find.to_sym
+      end
 
-    example "finds the added #{error_to_find}" do
+      Object.const_set error_to_find, Class.new(StandardError)
+
       expect(list_of_errors_and_exceptions).to include error_to_find
+    end
+  end
+
+  it 'rejects constants that do not have error or exception in them' do
+
+    %w(WeirdConstant Erroneous WindowsSucks MathIsCool ExeptionalMistake
+      ERR0r NoInspirationLeft ).each do |error_not_to_find|
+
+      if Module.constants.first.kind_of? Symbol
+        error_not_to_find = error_not_to_find.to_sym
+      end
+
+      Object.const_set error_not_to_find, Class.new(StandardError)
+
+      expect(list_of_errors_and_exceptions).not_to include error_not_to_find
     end
   end
 end


### PR DESCRIPTION
First test is not sufficient. `list_of_errors_and_exceptions` simply returning array of `Module.constants` passes. Second test tests that all constants not having 'error' or 'exception' in them are ignored.